### PR TITLE
fix query string on url

### DIFF
--- a/src/rest-client.ts
+++ b/src/rest-client.ts
@@ -109,7 +109,11 @@ export function createRestAPI(url: string, headers?: HeadersInit) {
         const init: RequestInit = { method, headers, body };
         if (credentialsString) init.credentials = credentialsString;
 
-        let request = new Request(url, init);
+        let query = '';
+        if(searchParams.toString()) {
+          query = `?${searchParams.toString()}`;
+        }
+        let request = new Request(`${url}${query}`, init);
 
         const response = await fetch(request);
         let text = await response.text();


### PR DESCRIPTION
the query string is not being added in any place I can see.  url is not associated at all with the searchparams variable.

circle error returned:
```
 "message": "param is missing or the value is empty: space_group_id\nDid you mean?  action\n               controller\n               format"
  
``